### PR TITLE
Feat replaces any if or unless tags

### DIFF
--- a/mustache_to_handlebars/main.py
+++ b/mustache_to_handlebars/main.py
@@ -19,7 +19,7 @@ HANDLEBARS_UNLESS_CLOSE = '{{/unless}}'
 HANDLEBARS_WHITESPACE_REMOVAL_CHAR = '~'
 
 class MustacheTagType(str, Enum):
-    IF = '#'
+    IF = '#'  # it is unclear if this should be an if(presence) OR each(list iteration) OR with(enter object context)
     UNLESS = '^'
     CLOSE = '/'
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='mustache_to_handlebars',
-      version='0.9',
+      version='0.91',
       description='converts mustache to handlebars templates',
       author='Justin Black',
       url='https://github.com/spacether/mustache_to_handlebars',

--- a/tests/test_mustache_to_handlebars.py
+++ b/tests/test_mustache_to_handlebars.py
@@ -57,15 +57,15 @@ class TestHelpers(unittest.TestCase):
             '{{/-first}}',
             '{{^-last}}',
             '{{/-last}}',
-            '{{/b}}{{/a}}',
             '  {{/otherList}}',
-            '{{/someList}}'
+            '{{/someList}}',
+            '{{/b}}{{/a}}'
         ])
         out_txt = main._convert_handlebars_to_mustache(in_txt)
         expected_out_txt = '\n'.join([
-            '{{#a}}{{#b}}',
-            '{{#someList~}}',
-            '  {{#otherList}}',
+            '{{#if a}}{{#if b}}',
+            '{{#if someList~}}',
+            '  {{#if otherList}}',
             '{{#if @first~}}',
             '{{/if~}}',
             '{{#if @last~}}',
@@ -74,9 +74,9 @@ class TestHelpers(unittest.TestCase):
             '{{/unless~}}',
             '{{#unless @last~}}',
             '{{/unless~}}',
-            '{{/b}}{{/a}}',
-            '  {{/otherList}}',
-            '{{/someList~}}'
+            '  {{/if}}',
+            '{{/if~}}',
+            '{{/if}}{{/if}}',
         ])
         self.assertEqual(
             out_txt, expected_out_txt)


### PR DESCRIPTION
Now any tag starting with # ^ / is recognized and replaced

Pro:
it detects all control tags

Con:
#someTag may be an if with or each tag in handlebars and there is no way to tell